### PR TITLE
Add active Clockify project task lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A FastMCP server that provides read-only access to Clockify time tracking data. 
 - 🔍 Query time entries by user, date range, and project
 - 📊 Get detailed time entry information
 - 👥 List workspace users
-- 📁 List projects and tags
+- 📁 List projects, active project tasks, and tags
 - ⏱️ Get currently running time entries
 - 🏢 Access workspace information
 
@@ -84,6 +84,22 @@ Get all projects in the workspace.
 **Parameters:**
 - `include_archived` (optional): Include archived projects (default: False)
 
+#### `list_active_project_tasks`
+Get active tasks for a specific project.
+
+**Parameters:**
+- `project_id` (required): Project ID
+
+**Returns:**
+JSON array of active task objects with `id`, `name`, `status`, and `project_id`.
+
+**Example:**
+```python
+list_active_project_tasks(
+    project_id="25b687e29ae1f428e7ebe123"
+)
+```
+
 #### `list_tags`
 Get all tags in the workspace.
 
@@ -100,6 +116,7 @@ This MCP server is designed to be used with AI agents. Example queries:
 
 - "Show me all time entries for the last week"
 - "What projects am I tracking time on?"
+- "Show me the active task IDs for project X"
 - "How many hours did I work on project X in January?"
 - "Who is currently tracking time?"
 

--- a/clockify_client.py
+++ b/clockify_client.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 import httpx
 
 from config import config
-from models import ProjectSummary, Tag, TimeEntry, User, Workspace
+from models import ProjectSummary, Tag, TaskSummary, TimeEntry, User, Workspace
 
 
 class ClockifyClient:
@@ -21,11 +21,18 @@ class ClockifyClient:
 
     async def _get(self, endpoint: str, params: Optional[dict[str, Any]] = None) -> Any:
         """Make a GET request to the Clockify API."""
+        data, _ = await self._get_response(endpoint, params=params)
+        return data
+
+    async def _get_response(
+        self, endpoint: str, params: Optional[dict[str, Any]] = None
+    ) -> tuple[Any, httpx.Headers]:
+        """Make a GET request to the Clockify API and return data with headers."""
         url = f"{self.base_url}{endpoint}"
         async with httpx.AsyncClient() as client:
             response = await client.get(url, headers=self.headers, params=params)
             response.raise_for_status()
-            return response.json()
+            return response.json(), response.headers
 
     async def get_workspace(self, workspace_id: Optional[str] = None) -> Workspace:
         """Get workspace information."""
@@ -55,6 +62,70 @@ class ClockifyClient:
         ws_id = workspace_id or self.workspace_id
         data = await self._get(f"/workspaces/{ws_id}/tags")
         return [Tag.model_validate(tag) for tag in data]
+
+    async def get_project_tasks(
+        self,
+        project_id: str,
+        workspace_id: Optional[str] = None,
+        is_active: bool = True,
+        page_size: int = 50,
+    ) -> list[TaskSummary]:
+        """Get tasks for a specific project."""
+        ws_id = workspace_id or self.workspace_id
+        tasks: list[TaskSummary] = []
+        page = 1
+
+        while True:
+            params: dict[str, Any] = {
+                "is-active": str(is_active).lower(),
+                "page": page,
+                "page-size": page_size,
+                "sort-column": "NAME",
+                "sort-order": "ASCENDING",
+            }
+            data, headers = await self._get_response(
+                f"/workspaces/{ws_id}/projects/{project_id}/tasks",
+                params=params,
+            )
+            page_tasks = [TaskSummary.model_validate(task) for task in data]
+            tasks.extend(page_tasks)
+
+            last_page = headers.get("Last-Page", "").lower() == "true"
+            if last_page or len(page_tasks) < page_size:
+                break
+
+            page += 1
+
+        return tasks
+
+    async def get_active_project_tasks(
+        self,
+        project_id: str,
+        workspace_id: Optional[str] = None,
+        page_size: int = 50,
+    ) -> list[TaskSummary]:
+        """Get active tasks for a specific project."""
+        tasks = await self.get_project_tasks(
+            project_id=project_id,
+            workspace_id=workspace_id,
+            is_active=True,
+            page_size=page_size,
+        )
+        active_tasks: list[TaskSummary] = []
+
+        for task in tasks:
+            if task.status and task.status.upper() != "ACTIVE":
+                continue
+            active_tasks.append(
+                TaskSummary(
+                    id=task.id,
+                    name=task.name,
+                    status="ACTIVE",
+                    project_id=task.project_id or project_id,
+                )
+            )
+
+        return active_tasks
 
     async def get_time_entry(
         self,

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Clockify MCP Server for querying time tracking data."""
 
+import json
 from datetime import datetime
 from typing import Optional
 
@@ -104,6 +105,24 @@ async def list_projects(include_archived: bool = False) -> str:
     """
     projects = await client.get_projects(archived=include_archived)
     return "\n".join([project.model_dump_json(indent=2) for project in projects])
+
+
+@mcp.tool
+async def list_active_project_tasks(project_id: str) -> str:
+    """
+    Get active tasks for a specific project.
+
+    Args:
+        project_id: The ID of the project whose active tasks to retrieve
+
+    Returns:
+        JSON array containing active task IDs, names, statuses, and project IDs
+    """
+    tasks = await client.get_active_project_tasks(project_id=project_id)
+    return json.dumps(
+        [task.model_dump(by_alias=False) for task in tasks],
+        indent=2,
+    )
 
 
 @mcp.tool

--- a/models.py
+++ b/models.py
@@ -32,6 +32,18 @@ class Task(BaseModel):
     project_id: Optional[str] = Field(None, alias="projectId")
 
 
+class TaskSummary(BaseModel):
+    """Summary information for a project task."""
+
+    id: str
+    name: str
+    status: Optional[str] = None
+    project_id: Optional[str] = Field(None, alias="projectId")
+
+    class Config:
+        populate_by_name = True
+
+
 class Tag(BaseModel):
     """Tag information."""
 

--- a/tests/test_active_project_tasks.py
+++ b/tests/test_active_project_tasks.py
@@ -1,0 +1,156 @@
+import importlib
+import json
+import unittest
+
+from clockify_client import ClockifyClient
+from config import config
+from models import TaskSummary
+
+
+class FakeClockifyClient(ClockifyClient):
+    def __init__(self, responses):
+        self.base_url = "https://api.clockify.me/api/v1"
+        self.headers = {"X-Api-Key": "test"}
+        self.workspace_id = "workspace-id"
+        self.responses = responses
+        self.calls = []
+
+    async def _get_response(self, endpoint, params=None):
+        self.calls.append((endpoint, params))
+        return self.responses.pop(0)
+
+
+class ActiveProjectTaskTests(unittest.IsolatedAsyncioTestCase):
+    async def test_get_project_tasks_sends_active_filter_and_endpoint(self):
+        client = FakeClockifyClient(
+            [
+                (
+                    [
+                        {
+                            "id": "task-1",
+                            "name": "Build",
+                            "status": "ACTIVE",
+                            "projectId": "project-1",
+                        }
+                    ],
+                    {"Last-Page": "true"},
+                )
+            ]
+        )
+
+        tasks = await client.get_project_tasks("project-1")
+
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(
+            client.calls[0][0],
+            "/workspaces/workspace-id/projects/project-1/tasks",
+        )
+        self.assertEqual(client.calls[0][1]["is-active"], "true")
+        self.assertEqual(client.calls[0][1]["sort-column"], "NAME")
+        self.assertEqual(client.calls[0][1]["sort-order"], "ASCENDING")
+
+    async def test_get_project_tasks_combines_paginated_results(self):
+        client = FakeClockifyClient(
+            [
+                (
+                    [
+                        {
+                            "id": "task-1",
+                            "name": "Build",
+                            "status": "ACTIVE",
+                            "projectId": "project-1",
+                        }
+                    ],
+                    {"Last-Page": "false"},
+                ),
+                (
+                    [
+                        {
+                            "id": "task-2",
+                            "name": "Test",
+                            "status": "ACTIVE",
+                            "projectId": "project-1",
+                        }
+                    ],
+                    {"Last-Page": "true"},
+                ),
+            ]
+        )
+
+        tasks = await client.get_project_tasks("project-1", page_size=1)
+
+        self.assertEqual([task.id for task in tasks], ["task-1", "task-2"])
+        self.assertEqual(client.calls[0][1]["page"], 1)
+        self.assertEqual(client.calls[1][1]["page"], 2)
+
+    async def test_get_active_project_tasks_filters_and_normalizes_status(self):
+        client = FakeClockifyClient(
+            [
+                (
+                    [
+                        {
+                            "id": "task-1",
+                            "name": "Build",
+                            "status": "ACTIVE",
+                            "projectId": "project-1",
+                        },
+                        {
+                            "id": "task-2",
+                            "name": "Closed",
+                            "status": "DONE",
+                            "projectId": "project-1",
+                        },
+                        {
+                            "id": "task-3",
+                            "name": "No Status",
+                            "projectId": "project-1",
+                        },
+                    ],
+                    {"Last-Page": "true"},
+                )
+            ]
+        )
+
+        tasks = await client.get_active_project_tasks("project-1")
+
+        self.assertEqual([task.id for task in tasks], ["task-1", "task-3"])
+        self.assertEqual([task.status for task in tasks], ["ACTIVE", "ACTIVE"])
+
+    async def test_mcp_tool_returns_expected_json_shape(self):
+        config.api_key = "test"
+        config.workspace_id = "workspace-id"
+        main = importlib.import_module("main")
+
+        class FakeMcpClient:
+            async def get_active_project_tasks(self, project_id):
+                return [
+                    TaskSummary(
+                        id="task-1",
+                        name="Build",
+                        status="ACTIVE",
+                        project_id=project_id,
+                    )
+                ]
+
+        original_client = main.client
+        main.client = FakeMcpClient()
+        try:
+            result = await main.list_active_project_tasks.fn("project-1")
+        finally:
+            main.client = original_client
+
+        self.assertEqual(
+            json.loads(result),
+            [
+                {
+                    "id": "task-1",
+                    "name": "Build",
+                    "status": "ACTIVE",
+                    "project_id": "project-1",
+                }
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only FastMCP tool to list active tasks for a Clockify project
- add Clockify client pagination and defensive active-task filtering/normalization
- document the new tool and add focused unit tests

## Tests
- uv run python -m unittest discover -s tests